### PR TITLE
Support to specify the range and resolution of parameter spaces

### DIFF
--- a/QuickCSF/QuickCSF.py
+++ b/QuickCSF/QuickCSF.py
@@ -219,6 +219,8 @@ class QuickCSFEstimator():
 		'''Create a new QuickCSF estimator with the specified input/output spaces
 
 			Args:
+				parameterSpace: 4,x numpy array of attributes to be used for four parameters searching
+					numpy.array([peakSensitivity, peakFrequency, bandwidth, logdelta])
 				stimulusSpace: 2,x numpy array of attributes to be used for stimulus generation
 					numpy.array([contrasts, frequencies])
 		'''
@@ -234,7 +236,7 @@ class QuickCSFEstimator():
 				makeBandwidthSpace(1, 10, 21),         # Log bandwidth
 				makeLogDeltaSpace(0.02, 2, 21)         # Low frequency truncation (log delta)
 			])
-		logger.debug(parameterSpace)
+			
 		logger.info('Initializing QuickCSFEStimator')
 		logger.debug('Initializing QuickCSFEstimator stimSpace='+str(stimulusSpace).replace('\n','')+', paramSpace='+str(parameterSpace).replace('\n',''))
 

--- a/QuickCSF/StimulusGenerators.py
+++ b/QuickCSF/StimulusGenerators.py
@@ -30,12 +30,22 @@ class QuickCSFGenerator(QuickCSF.QuickCSFEstimator):
 		size=100, orientation=None,
 		minContrast=.01, maxContrast=1.0, contrastResolution=24,
 		minFrequency=0.2, maxFrequency=36.0, frequencyResolution=20,
+		minPeakSensitivity=2, maxPeakSensitivity=1000, peakSensitivityResolution=28,
+		minPeakFrequency=0.2, maxPeakFrequency=20, peakFrequencyResolution=21,
+		minBandwidth=1, maxBandwidth=10, bandwidthResolution=21,
+		minLogDelta=0.02, maxLogDelta=2, logDeltaResolution=21,
 		degreesToPixels=None
 	):
 		super().__init__(
 			stimulusSpace = numpy.array([
 				QuickCSF.makeContrastSpace(minContrast, maxContrast, contrastResolution),
 				QuickCSF.makeFrequencySpace(minFrequency, maxFrequency, frequencyResolution)
+			]),
+			parameterSpace = numpy.array([
+				QuickCSF.makePeakSensitivitySpace(minPeakSensitivity, maxPeakSensitivity, peakSensitivityResolution),
+				QuickCSF.makePeakFrequencySpace(minPeakFrequency, maxPeakFrequency, peakFrequencyResolution),
+				QuickCSF.makeBandwidthSpace(minBandwidth, maxBandwidth, bandwidthResolution),
+				QuickCSF.makeLogDeltaSpace(minLogDelta, maxLogDelta, logDeltaResolution)
 			])
 		)
 

--- a/QuickCSF/app.py
+++ b/QuickCSF/app.py
@@ -114,7 +114,7 @@ def getSettings():
 	controllerSettings.add_argument('--waitForReady', default=False, action='store_true', help='Wait for the participant to indicate they are ready for the next trial')
 
 	stimulusSettings = parser.add_argument_group('Stimuli')
-	stimulusSettings.add_argument('-minc', '--minContrast', type=float, default=.01, help='The lowest contrast value to measure (0.0-1.0)')
+	stimulusSettings.add_argument('-minc', '--minContrast', type=float, default=.001, help='The lowest contrast value to measure (0.0-1.0)')
 	stimulusSettings.add_argument('-maxc', '--maxContrast', type=float, default=1.0, help='The highest contrast value to measure (0.0-1.0)')
 	stimulusSettings.add_argument('-cr', '--contrastResolution', type=int, default=24, help='The number of contrast steps')
 
@@ -153,6 +153,12 @@ def main():
 	settings = getSettings()
 
 	if not settings is None:
+		# parameter validation: peak sensitivty space and peak frequency space should be subspaces of stimulus spaces (1/contrast, frequency)
+		if not (settings['Parameters']['minPeakSensitivity'] >= 1/settings['Stimuli']['maxContrast'] and settings['Parameters']['maxPeakSensitivity'] <= 1/settings['Stimuli']['minContrast']):
+			raise ValueError("Please increase the range of contrast space or decrease the range of peak sensitivity space.")
+		if not (settings['Parameters']['minPeakFrequency'] >= settings['Stimuli']['minFrequency'] and settings['Parameters']['maxPeakFrequency'] <= settings['Stimuli']['maxFrequency']):
+			raise ValueError("Please increase the range of frequency space or decrease the range of peak frequency space.")
+
 		logPath = pathlib.Path(settings['outputFile']).parent
 		log.startLog(settings['sessionID'], logPath)
 		run(settings)

--- a/QuickCSF/app.py
+++ b/QuickCSF/app.py
@@ -69,7 +69,7 @@ def _start():
 
 	degreesToPixels = functools.partial(screens.degreesToPixels, distance_mm=settings['distance_mm'])
 
-	stimGenerator = StimulusGenerators.QuickCSFGenerator(degreesToPixels=degreesToPixels, **settings['Stimuli'])
+	stimGenerator = StimulusGenerators.QuickCSFGenerator(degreesToPixels=degreesToPixels, **settings['Stimuli'], **settings['Parameters'])
 	controller = CSFController.Controller_2AFC(stimGenerator, **settings['Controller'])
 
 	mainWindow.participantReady.connect(controller.onParticipantReady)
@@ -124,6 +124,23 @@ def getSettings():
 
 	stimulusSettings.add_argument('--size', type=int, default=3, help='Gabor patch size in (degrees)')
 	stimulusSettings.add_argument('--orientation', type=float, help='Orientation of gabor patch (degrees). If unspecified, each trial will be random')
+
+	parameterSettings = parser.add_argument_group('Parameters')
+	parameterSettings.add_argument('-minps', '--minPeakSensitivity', type=float, default=2.0, help='The lower bound of peak sensitivity value (>1.0)')
+	parameterSettings.add_argument('-maxps', '--maxPeakSensitivity', type=float, default=1000.0, help='The upper bound of peak sensitivity value')
+	parameterSettings.add_argument('-psr', '--peakSensitivityResolution', type=int, default=28, help='The number of peak sensitivity steps')
+	
+	parameterSettings.add_argument('-minpf', '--minPeakFrequency', type=float, default=.2, help='The lower bound of peak frequency value (>0)')
+	parameterSettings.add_argument('-maxpf', '--maxPeakFrequency', type=float, default=20.0, help='The upper bound of peak frequency value')
+	parameterSettings.add_argument('-pfr', '--peakFrequencyResolution', type=int, default=21, help='The number of peak frequency steps')
+	
+	parameterSettings.add_argument('-minb', '--minBandwidth', type=float, default=1.0, help='The lower bound of bandwidth value')
+	parameterSettings.add_argument('-maxb', '--maxBandwidth', type=float, default=10.0, help='The upper bound of bandwidth value')
+	parameterSettings.add_argument('-br', '--bandwidthResolution', type=int, default=21, help='The number of bandwidth steps')
+	
+	parameterSettings.add_argument('-mind', '--minLogDelta', type=float, default=.02, help='The lower bound of logdelta value')
+	parameterSettings.add_argument('-maxd', '--maxLogDelta', type=float, default=2.0, help='The upper bound of logdelta value')
+	parameterSettings.add_argument('-dr', '--logDeltaResolution', type=int, default=21, help='The number of logdelta steps')
 
 	settings = argparseqt.groupingTools.parseIntoGroups(parser)
 	if None in [settings['sessionID'], settings['distance_mm']]:

--- a/QuickCSF/simulate.py
+++ b/QuickCSF/simulate.py
@@ -99,7 +99,7 @@ def runSimulation(
 	imagePath=None,
 	usePerfectResponses=False,
 	stimuli={
-		'minContrast':0.01, 'maxContrast':1, 'contrastResolution':24,
+		'minContrast':0.001, 'maxContrast':1, 'contrastResolution':24,
 		'minFrequency':.2, 'maxFrequency':36, 'frequencyResolution':20,
 	},
 	parameters={
@@ -219,7 +219,7 @@ if __name__ == '__main__':
 	parser.add_argument('-perfect', '--usePerfectResponses', default=False, action='store_true', help='Whether to simulate perfect responses, rather than probablistic ones')
 
 	stimuliSettings = parser.add_argument_group('stimuli')
-	stimuliSettings.add_argument('-minc', '--minContrast', type=float, default=.01, help='The lowest contrast value to measure (0.0-1.0)')
+	stimuliSettings.add_argument('-minc', '--minContrast', type=float, default=.001, help='The lowest contrast value to measure (0.0-1.0)')
 	stimuliSettings.add_argument('-maxc', '--maxContrast', type=float, default=1.0, help='The highest contrast value to measure (0.0-1.0)')
 	stimuliSettings.add_argument('-cr', '--contrastResolution', type=int, default=24, help='The number of contrast steps')
 
@@ -257,4 +257,10 @@ if __name__ == '__main__':
 		settings = ui.getSettings(parser, settings, ['trials'])
 
 	if settings is not None:
+		# parameter validation: peak sensitivty space and peak frequency space should be subspaces of stimulus spaces (1/contrast, frequency)
+		if not (settings['parameters']['minPeakSensitivity'] >= 1/settings['stimuli']['maxContrast'] and settings['parameters']['maxPeakSensitivity'] <= 1/settings['stimuli']['minContrast']):
+			raise ValueError("Please increase the range of contrast space or decrease the range of peak sensitivity space.")
+		if not (settings['parameters']['minPeakFrequency'] >= settings['stimuli']['minFrequency'] and settings['parameters']['maxPeakFrequency'] <= settings['stimuli']['maxFrequency']):
+			raise ValueError("Please increase the range of frequency space or decrease the range of peak frequency space.")
+
 		runSimulation(**settings)


### PR DESCRIPTION
Commit 1. The hard-code mapping function is replaced by the mapping function based on specific parameter spaces defined by users. The original hard-code mapping function can be regarded as the mapping function of the parameter space with special ranges and resolutions, which are served as the default values of the new mapping function.
```
peakSensitivity = 0.1*params[:,0] + 0.3
peakFrequency = -0.7 + 0.1*params[:,1]
bandwidth = 0.05 * params[:,2]
logDelta = -1.7 + 0.1 * params[:,3]
```
```
parameterSettings = parser.add_argument_group('Parameters')
parameterSettings.add_argument('-minps', '--minPeakSensitivity', type=float, default=2.0, help='The lower bound of peak sensitivity value (>1.0)')
parameterSettings.add_argument('-maxps', '--maxPeakSensitivity', type=float, default=1000.0, help='The upper bound of peak sensitivity value')
parameterSettings.add_argument('-psr', '--peakSensitivityResolution', type=int, default=28, help='The number of peak sensitivity steps')

parameterSettings.add_argument('-minpf', '--minPeakFrequency', type=float, default=.2, help='The lower bound of peak frequency value (>0)')
parameterSettings.add_argument('-maxpf', '--maxPeakFrequency', type=float, default=20.0, help='The upper bound of peak frequency value')
parameterSettings.add_argument('-pfr', '--peakFrequencyResolution', type=int, default=21, help='The number of peak frequency steps')

parameterSettings.add_argument('-minb', '--minBandwidth', type=float, default=1.0, help='The lower bound of bandwidth value')
parameterSettings.add_argument('-maxb', '--maxBandwidth', type=float, default=10.0, help='The upper bound of bandwidth value')
parameterSettings.add_argument('-br', '--bandwidthResolution', type=int, default=21, help='The number of bandwidth steps')

parameterSettings.add_argument('-mind', '--minLogDelta', type=float, default=.02, help='The lower bound of logdelta value')
parameterSettings.add_argument('-maxd', '--maxLogDelta', type=float, default=2.0, help='The upper bound of logdelta value')
parameterSettings.add_argument('-dr', '--logDeltaResolution', type=int, default=21, help='The number of logdelta steps')
```

Commit 2. The peak sensitivity space and peak frequency space should be subspaces of stimuli spaces (1/contrast, frequency). Thus, a simple parameter validation is added to check whether the range of peak sensitivity is smaller than the range of 1/contrast. For example, the range of contrast (0.01, 1) corresponds to the range of sensitivity (1, 100). However, it is too small for searching the value of peak sensitivity in the range of (2, 1000).