### PR TITLE
Added Peripheral CSF parameters

### DIFF
--- a/QuickCSF/QuickCSF.py
+++ b/QuickCSF/QuickCSF.py
@@ -108,7 +108,7 @@ class QuickCSFEstimator():
 		else:
 			parameterSpace = [
 				numpy.arange(0, 32),	# Peak sensitivity (32 values from 2..256)
-				numpy.arange(0, 8) ,	# Peak frequency
+				numpy.arange(0, 28) ,	# Peak frequency
 				numpy.arange(0, 27),	# Log bandwidth
 				numpy.arange(0, 41)	 # High frequency truncation limit
 			]

--- a/QuickCSF/plot.py
+++ b/QuickCSF/plot.py
@@ -3,7 +3,7 @@ import numpy
 import matplotlib
 import matplotlib.pyplot as plt
 
-from . import QuickCSF
+import QuickCSF
 
 #frequencyDomain = QuickCSF.makeFrequencySpace(.005, 80, 50).reshape(-1,1)
 
@@ -21,7 +21,7 @@ def plot(qCSFEstimator, graph=None, unmappedTrueParams=None, showNumbers=True, s
 			plt.show()
 
 	if unmappedTrueParams is not None:
-		truthData = QuickCSF.csf_unmapped(unmappedTrueParams.reshape(1, -1), frequencyDomain)
+		truthData = qCSFEstimator.csf_unmapped(unmappedTrueParams.reshape(1, -1), frequencyDomain)
 		truthData = numpy.power(10, truthData)
 		truthLine = graph.fill_between(
 			frequencyDomain.reshape(-1),
@@ -38,7 +38,7 @@ def plot(qCSFEstimator, graph=None, unmappedTrueParams=None, showNumbers=True, s
 		estimatedParamMeans['bandwidth'],
 		estimatedParamMeans['delta'],
 	]])
-	estimatedData = QuickCSF.csf_unmapped(estimatedParamMeans.reshape(1, -1), frequencyDomain)
+	estimatedData = qCSFEstimator.csf_unmapped(estimatedParamMeans.reshape(1, -1), frequencyDomain)
 	estimatedData = numpy.power(10, estimatedData)
 
 	estimatedLine = graph.fill_between(
@@ -74,13 +74,13 @@ def plot(qCSFEstimator, graph=None, unmappedTrueParams=None, showNumbers=True, s
 	graph.grid()
 
 	if showNumbers:
-		estimatedParamMeans = QuickCSF.mapCSFParams(estimatedParamMeans, exponify=True)
+		estimatedParamMeans = qCSFEstimator.mapCSFParams(estimatedParamMeans, exponify=True)
 		estimatedParamMeans = estimatedParamMeans.reshape(1,-1).tolist()[0]
 		paramEstimates = '%03.2f, %.4f, %.4f, %.4f' % tuple(estimatedParamMeans)
 		estimatedLine.set_label(f'Estim: {paramEstimates}')
 
 		if truthData is not None:
-			trueParams = QuickCSF.mapCSFParams(unmappedTrueParams, True).T.tolist()[0]
+			trueParams = qCSFEstimator.mapCSFParams(unmappedTrueParams, True).T.tolist()[0]
 			trueParams = '%03.2f, %.4f, %.4f, %.4f' % tuple(trueParams)
 			truthLine.set_label(f'Truth: {trueParams}')
 

--- a/QuickCSF/plot.py
+++ b/QuickCSF/plot.py
@@ -3,7 +3,7 @@ import numpy
 import matplotlib
 import matplotlib.pyplot as plt
 
-import QuickCSF
+from . import QuickCSF
 
 #frequencyDomain = QuickCSF.makeFrequencySpace(.005, 80, 50).reshape(-1,1)
 

--- a/QuickCSF/simulate.py
+++ b/QuickCSF/simulate.py
@@ -11,8 +11,8 @@ import numpy
 import matplotlib.pyplot as plt
 import pathlib
 
-import QuickCSF
-import plot
+from . import QuickCSF
+from .plot import plot
 
 logger = logging.getLogger('QuickCSF.simulate')
 
@@ -50,7 +50,7 @@ def runSimulation(
 	]])
 	qcsf = QuickCSF.QuickCSFEstimator(stimulusSpace, periphery=periphery)
 
-	graph = plot.plot(qcsf, unmappedTrueParams=unmappedTrueParams, show = imagePath is None)
+	graph = plot(qcsf, unmappedTrueParams=unmappedTrueParams, show = imagePath is None)
 
 	# Trial loop
 	for i in range(trials):
@@ -62,7 +62,7 @@ def runSimulation(
 		if usePerfectResponses:
 			logger.debug('Simulating perfect response')
 			frequency = newStimValues[:,1]
-			trueSens = numpy.power(10, QuickCSF.csf_unmapped(unmappedTrueParams, numpy.array([frequency])))
+			trueSens = numpy.power(10, qcsf.csf_unmapped(unmappedTrueParams, numpy.array([frequency])))
 			testContrast = newStimValues[:,0]
 			testSens = 1 / testContrast
 
@@ -77,7 +77,7 @@ def runSimulation(
 		# Update the plot
 		graph.clear()
 		graph.set_title(f'Estimated Contrast Sensitivity Function ({i+1})')
-		plot.plot(qcsf, graph, unmappedTrueParams, show = imagePath is None)
+		plot(qcsf, graph, unmappedTrueParams, show = imagePath is None)
 
 		if imagePath is not None:
 			plt.savefig(pathlib.Path(imagePath+'/%f.png' % time.time()).resolve())
@@ -123,7 +123,7 @@ def entropyPlot(qcsf):
 
 
 if __name__ == '__main__':
-	import log
+	from . import log
 	log.startLog()
 
 	parser = argparse.ArgumentParser()

--- a/README.md
+++ b/README.md
@@ -2,11 +2,19 @@
 
 A fast, adaptive approach to estimating contrast sensitivity function parameters.
 
-This implmentation is based on:
+This implementation is based on:
 
 > Lesmes, L. A., Lu, Z. L., Baek, J., & Albright, T. D. (2010). Bayesian adaptive estimation of the contrast sensitivity function: The quick CSF method. *Journal of vision*, 10(3), 17-17.
 
-Special thanks to Dr. Tianshi Lu at Wichita State University for providing a Matlab implemenation of the fundamental algorithm and Dr. Rui Ni at Wichita State University for the motivation.
+Special thanks to Dr. Tianshi Lu at Wichita State University for providing a Matlab implementation of the fundamental algorithm and Dr. Rui Ni at Wichita State University for the motivation.
+
+Peripheral CSF based on 
+
+> Rosén, R., Lundström, L., Venkataraman A.P., Winter, S., Unsbo, P. (2014).
+	Quick contrast sensitivity measurements in the periphery.
+	Journal of Vision July 2014, Vol.14, 3. doi:https://doi.org/10.1167/14.8.3
+
+Thanks to Prof. Andrew Turpin at Lions Eye Institute, Australia, for incorporating the peripheral parameterisation into our code and providing the noQT option..
 
 ## Dependencies
 ~~~~
@@ -14,10 +22,8 @@ $ pip3 install -e .
 ~~~~
 Requires:
 * `numpy`
-* `qtpy`
+* `qtpy` (not necessary for simulation)
 * Qt bindings (via `PySide2`, `PyQt5`, `PySide`, or `PyQt`)
-
-Optional (for simulation visuals):
 * `matplotlib`
 
 ## Usage
@@ -30,6 +36,7 @@ A settings dialog will appear; session ID and viewing distance are required. Arg
 ~~~bash
 $ python -m QuickCSF.app --help
 ~~~
+
 ### Simulate and visualize an evaluation
 Run:
 ~~~bash
@@ -38,4 +45,9 @@ $ python -m QuickCSF.simulate
 A settings dialog will appear; the number of trials is required. Arguments can also be specified on the command line. use the `--help` flag to see all options:
 ~~~bash
 $ python -m QuickCSF.simulate --help
+~~~
+
+As an example for a command line version that does not use `qtpy`
+~~~bash
+$ python -m QuickCSF.simulate --noQT --periphery -minf 1 -maxf 50 -fr 50 -cr 64 -s 27 -d 20 -b 10 -perfect -n 200 
 ~~~


### PR DESCRIPTION
Added parameterisation to support 

>      Robert Rosén; Linda Lundström; Abinaya Priya Venkataraman; Simon Winter; Peter Unsbo (2014).
>	Quick contrast sensitivity measurements in the periphery.
>	Journal of Vision July 2014, Vol.14, 3. [doi:](https://doi.org/10.1167/14.8.3)

This involved: 

 1. pushing functions csf_unmapped(), csf(), aulcsf() and mapCSFParams() into the QuickCSF class; and
 2. adding some extra parameters for the peripheral case based on the above paper.

I also added a command line flag of "noQT" so the code can be run without plotting to the screen.

